### PR TITLE
[android-security-13.0.0_r9] Ensure that SecureNFC setting cannot be bypassed

### DIFF
--- a/src/com/android/nfc/NfcService.java
+++ b/src/com/android/nfc/NfcService.java
@@ -1166,6 +1166,12 @@ public class NfcService implements DeviceHostListener {
         }
     }
 
+    public boolean isSecureNfcEnabled() {
+        synchronized (NfcService.this) {
+            return mIsSecureNfcEnabled;
+        }
+    }
+
     final class NfcAdapterService extends INfcAdapter.Stub {
         @Override
         public boolean enable() throws RemoteException {

--- a/src/com/android/nfc/cardemulation/HostEmulationManager.java
+++ b/src/com/android/nfc/cardemulation/HostEmulationManager.java
@@ -188,7 +188,9 @@ public class HostEmulationManager {
                     // Resolve to default
                     // Check if resolvedService requires unlock
                     ApduServiceInfo defaultServiceInfo = resolveInfo.defaultService;
-                    if (defaultServiceInfo.requiresUnlock() && mKeyguard.isKeyguardLocked()) {
+                    if ((defaultServiceInfo.requiresUnlock()
+                            || NfcService.getInstance().isSecureNfcEnabled())
+                          && mKeyguard.isKeyguardLocked()) {
                         NfcService.getInstance().sendRequireUnlockIntent();
                         NfcService.getInstance().sendData(AID_NOT_FOUND);
                         if (DBG) Log.d(TAG, "requiresUnlock()! show toast");


### PR DESCRIPTION
Bug: 268038643
Test: ctsverifier
(cherry picked from https://googleplex-android-review.googlesource.com/q/commit:6cb53d963d376b97963120a4d2c7df961789e428) Merged-In: I53a45c3600dc6bba7009921ca5135ee37b5edfd0 Change-Id: I53a45c3600dc6bba7009921ca5135ee37b5edfd0